### PR TITLE
Test PR with invalid release label [test-label-validation-1753174127-140150568728448-81697-7995]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,8 @@
 # Testing file
 
 This file contains random data, used for PR testing.
+
+
+## Test Invalid Release 1753174131
+
+Testing workflow failure with invalid release label.


### PR DESCRIPTION

This PR tests workflow failure with invalid release value.

```yaml
release: invalid-version  # This should cause workflow to fail
backport: 1.0            # This is valid
```

The workflow should fail because 'invalid-version' is not in the accepted releases list.
