### PR TITLE
Test PR with invalid release label [test-label-validation-1753179381-140435268020096-115592-9270]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -18,3 +18,8 @@ This file contains random data, used for PR testing.
 Testing the complete workflow chain:
 1. Fork trigger collects PR metadata
 2. Triage workflow downloads artifact and applies label
+
+
+## Test Invalid Release 1753179384
+
+Testing workflow failure with invalid release label.


### PR DESCRIPTION

This PR tests workflow failure with invalid release value.

```yaml
release: invalid-version  # This should cause workflow to fail
backport: 1.0            # This is valid
```

The workflow should fail because 'invalid-version' is not in the accepted releases list.
