### PR TITLE
Test PR with invalid backport label [test-label-validation-1753180382-140471630432128-127048-9721]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -18,3 +18,8 @@ This file contains random data, used for PR testing.
 Testing the complete workflow chain:
 1. Fork trigger collects PR metadata
 2. Triage workflow downloads artifact and applies label
+
+
+## Test Invalid Backport 1753180479
+
+Testing workflow failure with invalid backport label.


### PR DESCRIPTION

This PR tests workflow failure with invalid backport value.

```yaml
release: 1.0                    # This is valid
backport: invalid-backport      # This should cause workflow to fail
```

The workflow should fail because 'invalid-backport' is not in the accepted
backports list.
