### PR TITLE
Test PR with invalid backport label [test-label-validation-1753263409-140217952827264-360058-2680]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,8 @@
 # Testing file
 
 This file contains random data, used for PR testing.
+
+
+## Test Invalid Backport 1753263517
+
+Testing workflow failure with invalid backport label.


### PR DESCRIPTION

This PR tests workflow failure with invalid backport value.

```yaml
release: 1.0                    # This is valid
backport: invalid-backport      # This should cause workflow to fail
```

The workflow should fail because 'invalid-backport' is not in the accepted
backports list.
